### PR TITLE
Changes to work with new v4 artifact actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,9 @@ jobs:
           TESTWHEEL_GENERATE_PATH: ${{ runner.temp }}/testwheel-out/${{ matrix.python-version }}/${{ matrix.os }}
         run: hatch run test:generate
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: patched-testwheel
+          name: patched-testwheel-${{ matrix.os }}-${{ matrix.python-version }}
           path: ${{ runner.temp }}/testwheel-out
 
   check:
@@ -102,9 +102,8 @@ jobs:
       - name: Install Hatch
         run: python -m pip install hatch
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: patched-testwheel
           path: ${{ runner.temp }}/testwheel-out
 
       - name: Check wheels


### PR DESCRIPTION
Our usage is affected by breaking changes in v3 -> v4.
Previously, multiple actions could upload artifacts to the same name, and then fetching that name with `download-artifact` would get the combination of all uploads.
That doesn't work anymore, but `download-artifact` will download all stored artifacts if `name` isn't passed, so the artifact name ultimately doesn't matter and we can just generate something unique based on matrix attributes.