### PR TITLE
fix: integration regressions with auditwheel update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Install Hatch
         run: python -m pip install hatch
 
+      - name: Install system test dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libbz2-dev
+
       - name: Run tests
         run: hatch run test:test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ src/repairwheel/_vendor
 
 [tool.ruff]
 line-length = 127
+src = ["src"]
+exclude = ["src/repairwheel/_vendor"]
+target-version = "py310"
+
+[tool.ruff.lint]
 select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions
@@ -52,21 +57,17 @@ select = [
   "RUF",  # ruff
   "UP",   # pyupgrade
   "W",    # pycodestyle
-  "W",    # pycodestyle
   "YTT",  # flake8-2020
 ]
 ignore = [
   "C901", # Function is too complex
   "RUF012", # https://github.com/astral-sh/ruff/issues/5243
 ]
-src = ["src"]
-exclude = ["src/repairwheel/_vendor"]
-target-version = "py310"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-between-types = 1
 lines-after-imports = 2
 known-first-party = ["build"]

--- a/src/repairwheel/__init__.py
+++ b/src/repairwheel/__init__.py
@@ -4,4 +4,4 @@
 repairwheel
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/repairwheel/_vendor/auditwheel/repair.py
+++ b/src/repairwheel/_vendor/auditwheel/repair.py
@@ -139,7 +139,7 @@ def repair_wheel(
         if sbom_data:
             sbom_dir = Path(dist_info_dirs[0], "sboms")
             sbom_dir.mkdir(exist_ok=True)
-            (sbom_dir / "auditwheel.cdx.json").write_text(json.dumps(sbom_data))
+            (sbom_dir / "repairwheel.cdx.json").write_text(json.dumps(sbom_data))
 
     return output_wheel
 

--- a/src/repairwheel/_vendor/auditwheel/sboms.py
+++ b/src/repairwheel/_vendor/auditwheel/sboms.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import typing
-from importlib import metadata
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -59,7 +58,7 @@ def create_sbom_for_wheel(
         "metadata": {
             "component": sbom_components[0],
             "tools": [
-                {"name": "auditwheel", "version": metadata.version("auditwheel")},
+                {"name": "repairwheel", "version": __import__("repairwheel").__version__},
             ],
         },
         # These are mutated below through the variables.

--- a/src/repairwheel/compat.py
+++ b/src/repairwheel/compat.py
@@ -18,9 +18,7 @@ class cached_property:
         if self.attrname is None:
             self.attrname = name
         elif name != self.attrname:
-            raise TypeError(
-                "Cannot assign the same cached_property to two different names " f"({self.attrname!r} and {name!r})."
-            )
+            raise TypeError(f"Cannot assign the same cached_property to two different names ({self.attrname!r} and {name!r}).")
 
     def __get__(self, instance, owner=None):
         if instance is None:
@@ -30,7 +28,7 @@ class cached_property:
         try:
             cache = instance.__dict__
         except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
-            msg = f"No '__dict__' attribute on {type(instance).__name__!r} " f"instance to cache {self.attrname!r} property."
+            msg = f"No '__dict__' attribute on {type(instance).__name__!r} instance to cache {self.attrname!r} property."
             raise TypeError(msg) from None
         val = cache.get(self.attrname, _NOT_FOUND)
         if val is _NOT_FOUND:

--- a/src/repairwheel/linux/elffile.py
+++ b/src/repairwheel/linux/elffile.py
@@ -1008,10 +1008,12 @@ class ElfFile:
         new_soname: bytes | None = None,
         new_rpath: bytes | None = None,
         needed_replacements: dict[bytes, bytes] | None = None,
+        needed_removals: set[bytes] | None = None,
         add_new_load: bool = False,
         place_phdrs_at_start_of_section: bool = False,
     ) -> tuple[SectionInfo, SectionInfo]:
         needed_replacements = needed_replacements or {}
+        needed_removals = needed_removals or set()
         cur_needed_names = []
         cur_rpath = b""
         cur_runpath = b""
@@ -1039,8 +1041,8 @@ class ElfFile:
         new_rpath = new_rpath or cur_rpath
 
         # Update our DT_NEEDED and DT_VERNEED lists
-        new_needed_names = [needed_replacements.get(e, e) for e in cur_needed_names]
-        new_verneed_names = [needed_replacements.get(e, e) for e in cur_verneed_names]
+        new_needed_names = [needed_replacements.get(e, e) for e in cur_needed_names if e not in needed_removals]
+        new_verneed_names = [needed_replacements.get(e, e) for e in cur_verneed_names if e not in needed_removals]
 
         # Next we need to figure out if we can replace the end of .dynstr.
         # We expect .dynstr to end with a substring starting with $PATCH$\0,
@@ -1168,11 +1170,13 @@ class ElfFile:
         new_soname: bytes | None = None,
         new_rpath: bytes | None = None,
         needed_replacements: dict[bytes, bytes] | None = None,
+        needed_removals: set[bytes] | None = None,
     ) -> None:
         if self.ehdr.e_type not in (ET_EXEC, ET_DYN):
             raise ValueError("ELF e_type must be ET_EXEC or ET_DYN")
 
         needed_replacements = needed_replacements or {}
+        needed_removals = needed_removals or set()
 
         self._fh.seek(0, io.SEEK_END)
         file_end = self._fh.tell()
@@ -1201,6 +1205,7 @@ class ElfFile:
             new_soname=new_soname,
             new_rpath=new_rpath,
             needed_replacements=needed_replacements,
+            needed_removals=needed_removals,
             add_new_load=add_new_load,
         )
 

--- a/src/repairwheel/linux/monkeypatch.py
+++ b/src/repairwheel/linux/monkeypatch.py
@@ -3,19 +3,20 @@ from pathlib import Path
 
 def patch_load_ld_paths(lib_paths: list[Path], use_sys_paths: bool) -> None:
     import repairwheel._vendor.auditwheel.lddtree
+    from repairwheel._vendor.auditwheel.libc import Libc
 
     if use_sys_paths:
         original_load_ld_paths = repairwheel._vendor.auditwheel.lddtree.load_ld_paths
 
-        def load_ld_paths(root: str = "/", prefix: str = "") -> dict[str, list[str]]:
-            ldpaths = original_load_ld_paths(root, prefix)
+        def load_ld_paths(libc: Libc | None = None, root: str = "/", prefix: str = "") -> dict[str, list[str]]:
+            ldpaths = original_load_ld_paths(libc, root, prefix)
             # Insert lib_paths at the beginning of the list
             ldpaths["env"][:0] = [str(lp) for lp in lib_paths]
             return ldpaths
 
     else:
 
-        def load_ld_paths(root: str = "/", prefix: str = "") -> dict[str, list[str]]:
+        def load_ld_paths(libc: Libc | None = None, root: str = "/", prefix: str = "") -> dict[str, list[str]]:
             return {
                 "env": [str(lp) for lp in lib_paths],
                 "conf": [],

--- a/src/repairwheel/linux/patcher.py
+++ b/src/repairwheel/linux/patcher.py
@@ -9,6 +9,12 @@ class RepairWheelElfPatcher:
             ef = ElfFile(f)
             ef.rewrite(needed_replacements=replacements)
 
+    def remove_needed(self, file_name: str, *sonames: str) -> None:
+        removals = {s.encode("utf-8") for s in sonames}
+        with open(file_name, "r+b") as f:
+            ef = ElfFile(f)
+            ef.rewrite(needed_removals=removals)
+
     def set_soname(self, file_name: str, new_so_name: str) -> None:
         with open(file_name, "r+b") as f:
             ef = ElfFile(f)

--- a/src/repairwheel/linux/repair.py
+++ b/src/repairwheel/linux/repair.py
@@ -17,9 +17,20 @@ def get_machine_from_wheel(wheel: Path) -> str:
     if len(tags) > 1:
         log.warning("Wheel %s has multiple tags; using first (%s)", wheel.name, first_tag)
 
-    # platform is like 'linux_x86_64' or 'manylinux_aarch64'
-    _, machine = first_tag.platform.split("_", 1)
-    return machine
+    # platform is like 'linux_x86_64', 'manylinux_2_5_x86_64',
+    # 'manylinux2014_aarch64', etc.  We can't simply split on '_'
+    # because manylinux tags embed a version number.  Instead, try
+    # each known architecture as a suffix.
+    from repairwheel._vendor.auditwheel.architecture import Architecture
+
+    plat = first_tag.platform
+    for arch in Architecture:
+        suffix = f"_{arch.value}"
+        if plat.endswith(suffix):
+            return arch.value
+
+    # Fallback: assume the architecture is the part after the last '_'.
+    return plat.rsplit("_", 1)[-1]
 
 
 def repair(wheel_file: Path, output_dir: Path, lib_path: list[Path], use_sys_paths: bool, verbosity: int = 0) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,7 @@
+import os
 import platform
+import subprocess
+import sys
 import tempfile
 import zipfile
 from datetime import datetime
@@ -38,3 +41,40 @@ def test_source_date_epoch(orig_py3_none_any_wheel: TestWheel) -> None:
         with zipfile.ZipFile(patched_wheel) as zf:
             for zi in zf.infolist():
                 assert zi.date_time == expected_zip_time
+
+
+def test_repair_is_idempotent(patched_wheel: Path) -> None:
+    """repair(repair(wheel)) must produce a byte-identical wheel."""
+    if "py3-none-any" in patched_wheel.name:
+        pytest.skip("py3-none-any wheel has no native deps to repair")
+
+    with tempfile.TemporaryDirectory(prefix="idempotent") as temp_dir:
+        out_dir = Path(temp_dir)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "repairwheel",
+                str(patched_wheel),
+                "--output-dir",
+                str(out_dir),
+            ],
+            env=dict(os.environ),
+            capture_output=True,
+            text=True,
+        )
+
+        re_patched = list(out_dir.glob("*.whl"))
+
+        if result.returncode != 0 and not re_patched:
+            # The backend (e.g. delvewheel) recognized the wheel as
+            # already repaired and refused to produce output.  That's
+            # idempotent by definition.
+            return
+
+        assert result.returncode == 0, f"repairwheel failed:\n{result.stdout}\n{result.stderr}"
+        assert len(re_patched) == 1, f"Expected 1 wheel, got {len(re_patched)}"
+        assert patched_wheel.read_bytes() == re_patched[0].read_bytes(), (
+            "Repairing an already-repaired wheel produced different output"
+        )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -75,6 +75,6 @@ def test_repair_is_idempotent(patched_wheel: Path) -> None:
 
         assert result.returncode == 0, f"repairwheel failed:\n{result.stdout}\n{result.stderr}"
         assert len(re_patched) == 1, f"Expected 1 wheel, got {len(re_patched)}"
-        assert patched_wheel.read_bytes() == re_patched[0].read_bytes(), (
-            "Repairing an already-repaired wheel produced different output"
-        )
+        assert (
+            patched_wheel.read_bytes() == re_patched[0].read_bytes()
+        ), "Repairing an already-repaired wheel produced different output"

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -1,0 +1,59 @@
+"""Tests for Linux-specific repair logic."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from repairwheel._vendor.auditwheel.libc import Libc
+from repairwheel.linux import monkeypatch
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Linux-only tests")
+
+
+class TestPatchLoadLdPaths:
+    """Verify the load_ld_paths monkeypatch matches auditwheel's expected signature."""
+
+    def _get_patched_fn(self, lib_paths, use_sys_paths):
+        monkeypatch.patch_load_ld_paths(lib_paths, use_sys_paths)
+        import repairwheel._vendor.auditwheel.lddtree
+
+        return repairwheel._vendor.auditwheel.lddtree.load_ld_paths
+
+    def test_use_sys_paths_accepts_libc_arg(self):
+        """With use_sys_paths=True, load_ld_paths(Libc.GLIBC) must work."""
+        load_ld_paths = self._get_patched_fn([], use_sys_paths=True)
+        result = load_ld_paths(Libc.GLIBC)
+        assert isinstance(result, dict)
+        assert "env" in result
+        assert "conf" in result
+        assert "interp" in result
+
+    def test_no_sys_paths_accepts_libc_arg(self):
+        """With use_sys_paths=False, load_ld_paths(Libc.GLIBC) must work."""
+        load_ld_paths = self._get_patched_fn([], use_sys_paths=False)
+        result = load_ld_paths(Libc.GLIBC)
+        assert result == {"env": [], "conf": [], "interp": []}
+
+    def test_no_sys_paths_includes_lib_paths(self):
+        """User-provided lib paths appear in the env key."""
+        lib_paths = [Path("/fake/lib1"), Path("/fake/lib2")]
+        load_ld_paths = self._get_patched_fn(lib_paths, use_sys_paths=False)
+        result = load_ld_paths(Libc.GLIBC)
+        assert result["env"] == ["/fake/lib1", "/fake/lib2"]
+        assert result["conf"] == []
+        assert result["interp"] == []
+
+    def test_use_sys_paths_prepends_lib_paths(self):
+        """User-provided lib paths are prepended to the env list."""
+        lib_paths = [Path("/fake/lib1")]
+        load_ld_paths = self._get_patched_fn(lib_paths, use_sys_paths=True)
+        result = load_ld_paths(Libc.GLIBC)
+        assert result["env"][0] == "/fake/lib1"
+
+    def test_accepts_none_libc(self):
+        """load_ld_paths(None) must also work (libc is Optional)."""
+        load_ld_paths = self._get_patched_fn([], use_sys_paths=True)
+        result = load_ld_paths(None)
+        assert isinstance(result, dict)
+        assert "env" in result

--- a/tests/test_linux_syslib.py
+++ b/tests/test_linux_syslib.py
@@ -306,9 +306,9 @@ class TestSyslibRepair:
         out2.mkdir()
         repaired2 = _run_repairwheel(repaired_wheel, syslib_env["lib_dir"], out2)
 
-        assert repaired_wheel.read_bytes() == repaired2.read_bytes(), (
-            "Repairing an already-repaired wheel produced different output"
-        )
+        assert (
+            repaired_wheel.read_bytes() == repaired2.read_bytes()
+        ), "Repairing an already-repaired wheel produced different output"
 
     def test_libpython_is_stripped(self, repaired_wheel: Path):
         """The repaired extension must NOT have a DT_NEEDED on libpython.
@@ -514,9 +514,9 @@ class TestSbomEndToEnd:
 
         sbom_entries = [n for n in names if n.endswith(".cdx.json")]
         assert sbom_entries, f"No SBOM found in wheel; files: {names}"
-        assert all("repairwheel.cdx.json" in n for n in sbom_entries), (
-            f"SBOM filename should be repairwheel.cdx.json, got: {sbom_entries}"
-        )
+        assert all(
+            "repairwheel.cdx.json" in n for n in sbom_entries
+        ), f"SBOM filename should be repairwheel.cdx.json, got: {sbom_entries}"
         assert not any("auditwheel.cdx.json" in n for n in names), "auditwheel.cdx.json should not exist in the wheel"
 
     def test_sbom_content_is_branded_repairwheel(self, repaired_bz2_wheel: Path):

--- a/tests/test_linux_syslib.py
+++ b/tests/test_linux_syslib.py
@@ -1,0 +1,541 @@
+"""Integration test: repair a wheel that links against non-allowlisted libraries.
+
+This test builds a tiny shared library (``libtestdep_syslib.so``), compiles
+a Python C extension that links against it, packages it into a wheel, and
+runs ``repairwheel`` with ``--lib-dir`` pointing at the custom library.
+Because the library is *not* on the manylinux allowlist, auditwheel will
+graft it into the wheel's ``.libs/`` directory.
+
+This exercises the full repair pipeline end-to-end on a real ELF binary,
+including:
+  - library discovery via ``load_ld_paths``  (issue #55 regression)
+  - ELF patching / RPATH rewriting
+  - manylinux tag assignment
+  - the SBOM vendor patch (``tools/vendoring/patches/auditwheel.patch``)
+
+Requirements (ubuntu-latest GitHub Actions runners satisfy all of these):
+  - Linux x86_64 or aarch64
+  - gcc / cc
+  - Python development headers  (``python3-dev``)
+
+The test is skipped automatically when any prerequisite is missing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import sysconfig
+import textwrap
+import zipfile
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+_SKIP_REASON: str | None = None
+
+if sys.platform != "linux":
+    _SKIP_REASON = "system-library integration test is Linux-only"
+elif platform.machine() not in ("x86_64", "aarch64"):
+    _SKIP_REASON = f"unsupported machine: {platform.machine()}"
+elif not shutil.which("cc") and not shutil.which("gcc"):
+    _SKIP_REASON = "no C compiler found (need gcc or cc)"
+elif not Path(sysconfig.get_path("include"), "Python.h").exists():
+    _SKIP_REASON = "Python.h not found (need python3-dev)"
+
+pytestmark = pytest.mark.skipif(_SKIP_REASON is not None, reason=_SKIP_REASON or "")
+
+
+# ---------------------------------------------------------------------------
+# C sources
+# ---------------------------------------------------------------------------
+
+# A trivial shared library that is NOT on the manylinux allowlist.
+_DEP_SOURCE = textwrap.dedent("""\
+    int dep_get_answer(void) { return 42; }
+""")
+
+# A Python C extension that links against our custom dep.
+_EXT_SOURCE = textwrap.dedent("""\
+    #define PY_SSIZE_T_CLEAN
+    #include <Python.h>
+
+    extern int dep_get_answer(void);
+
+    static PyObject *
+    syslib_test_answer(PyObject *self, PyObject *args)
+    {
+        return PyLong_FromLong(dep_get_answer());
+    }
+
+    static PyMethodDef methods[] = {
+        {"answer", syslib_test_answer, METH_NOARGS, NULL},
+        {NULL, NULL, 0, NULL}
+    };
+
+    static struct PyModuleDef moddef = {
+        PyModuleDef_HEAD_INIT, "syslib_test", NULL, -1, methods
+    };
+
+    PyMODINIT_FUNC PyInit_syslib_test(void)
+    {
+        return PyModule_Create(&moddef);
+    }
+""")
+
+_WHEEL_NAME = "syslibtest"
+_WHEEL_VERSION = "0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cc() -> str:
+    return shutil.which("cc") or shutil.which("gcc") or "cc"
+
+
+def _build_dep(src_dir: Path, lib_dir: Path) -> Path:
+    """Build libtestdep_syslib.so — a non-allowlisted shared library."""
+    src_file = src_dir / "testdep_syslib.c"
+    src_file.write_text(_DEP_SOURCE)
+    out_file = lib_dir / "libtestdep_syslib.so"
+
+    subprocess.check_call(
+        [
+            _cc(),
+            "-shared",
+            "-fPIC",
+            "-Wl,-soname,libtestdep_syslib.so",
+            "-o",
+            str(out_file),
+            str(src_file),
+        ]
+    )
+    return out_file
+
+
+def _build_ext(src_dir: Path, build_dir: Path, lib_dir: Path) -> Path:
+    """Compile the C extension, linking against our custom dep and libpython.
+
+    Linking against libpython exercises the ``remove_needed`` codepath
+    in vendored repair.py (via ``LIBPYTHON_RE``): manylinux/musllinux
+    wheels must NOT carry a libpython dependency.
+    """
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    out_file = build_dir / f"syslib_test{ext_suffix}"
+
+    src_file = src_dir / "syslib_test.c"
+    src_file.write_text(_EXT_SOURCE)
+
+    include = sysconfig.get_path("include")
+    libdir = sysconfig.get_config_var("LIBDIR") or "/usr/lib"
+
+    # Determine the python library name (e.g. "python3.13")
+    ldlibrary = sysconfig.get_config_var("LDLIBRARY") or ""
+    # LDLIBRARY is like "libpython3.13.so" — extract "python3.13"
+    pylib_match = re.match(r"lib(.+?)\.so", ldlibrary)
+    pylib = pylib_match.group(1) if pylib_match else None
+
+    link_args = [
+        _cc(),
+        "-shared",
+        "-fPIC",
+        f"-I{include}",
+        f"-L{lib_dir}",
+        f"-L{libdir}",
+        "-Wl,--no-as-needed",
+        "-ltestdep_syslib",
+    ]
+    if pylib:
+        link_args.append(f"-l{pylib}")
+    link_args += [
+        f"-Wl,-rpath,{lib_dir}",
+        "-o",
+        str(out_file),
+        str(src_file),
+    ]
+
+    subprocess.check_call(link_args)
+    return out_file
+
+
+def _make_wheel(ext_file: Path, out_dir: Path) -> Path:
+    """Package the extension into a minimal wheel."""
+    machine = platform.machine()
+    py_ver = f"cp{sys.version_info[0]}{sys.version_info[1]}"
+    plat_tag = f"linux_{machine}"
+    tag = f"{py_ver}-{py_ver}-{plat_tag}"
+
+    metadata = f"Metadata-Version: 2.1\nName: {_WHEEL_NAME}\nVersion: {_WHEEL_VERSION}\n"
+    wheel_info = f"Wheel-Version: 1.0\nGenerator: test_syslib_integration\nRoot-Is-Purelib: false\nTag: {tag}\n"
+
+    ext_name = ext_file.name
+    dist_info = f"{_WHEEL_NAME}-{_WHEEL_VERSION}.dist-info"
+    files: dict[str, bytes] = {
+        f"{_WHEEL_NAME}/{ext_name}": ext_file.read_bytes(),
+        f"{dist_info}/METADATA": metadata.encode(),
+        f"{dist_info}/WHEEL": wheel_info.encode(),
+        f"{dist_info}/top_level.txt": b"syslib_test\n",
+    }
+
+    record_path = f"{dist_info}/RECORD"
+    records = []
+    for fname, data in sorted(files.items()):
+        digest = urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        records.append(f"{fname},sha256={digest},{len(data)}")
+    records.append(f"{record_path},,")
+    files[record_path] = "\n".join(records).encode()
+
+    wheel_path = out_dir / f"{_WHEEL_NAME}-{_WHEEL_VERSION}-{tag}.whl"
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fname in sorted(files):
+            zinfo = zipfile.ZipInfo(fname, date_time=(1980, 1, 1, 0, 0, 0))
+            zinfo.external_attr = 0o100664 << 16
+            zf.writestr(zinfo, files[fname])
+
+    return wheel_path
+
+
+def _run_repairwheel(wheel: Path, lib_dir: Path, out_dir: Path) -> Path:
+    """Run ``python -m repairwheel`` on *wheel*, return the repaired path."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "repairwheel",
+            str(wheel),
+            "--output-dir",
+            str(out_dir),
+            "--lib-dir",
+            str(lib_dir),
+        ],
+        env={**os.environ},
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"repairwheel exited {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+    results = list(out_dir.glob("*.whl"))
+    assert len(results) == 1, f"Expected 1 repaired wheel, got {len(results)}"
+    return results[0]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def syslib_env(tmp_path: Path) -> dict[str, Path]:
+    """Build the custom dep, extension, and wheel. Return paths."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    wheel_dir = tmp_path / "wheels"
+    wheel_dir.mkdir()
+    out_dir = tmp_path / "repaired"
+    out_dir.mkdir()
+
+    _build_dep(src_dir, lib_dir)
+    ext = _build_ext(src_dir, build_dir, lib_dir)
+    wheel = _make_wheel(ext, wheel_dir)
+
+    return {
+        "lib_dir": lib_dir,
+        "wheel": wheel,
+        "out_dir": out_dir,
+    }
+
+
+@pytest.fixture()
+def repaired_wheel(syslib_env: dict[str, Path]) -> Path:
+    """Repair the wheel and return the repaired path."""
+    return _run_repairwheel(
+        syslib_env["wheel"],
+        syslib_env["lib_dir"],
+        syslib_env["out_dir"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyslibRepair:
+    """Repair a wheel that links against a non-allowlisted shared library."""
+
+    def test_repair_succeeds(self, repaired_wheel: Path):
+        """repairwheel must complete without error."""
+        assert repaired_wheel.exists()
+
+    def test_repaired_wheel_bundles_dep(self, repaired_wheel: Path):
+        """The repaired wheel must graft libtestdep_syslib into .libs/."""
+        with zipfile.ZipFile(repaired_wheel) as zf:
+            names = zf.namelist()
+
+        libs_entries = [n for n in names if ".libs/" in n]
+        dep_entries = [n for n in libs_entries if "testdep_syslib" in n]
+        assert dep_entries, f"Expected libtestdep_syslib in .libs/, got: {libs_entries}"
+
+    def test_repaired_wheel_has_manylinux_tag(self, repaired_wheel: Path):
+        """The repaired wheel should be tagged manylinux, not plain linux."""
+        assert "manylinux" in repaired_wheel.name, f"Expected manylinux tag in: {repaired_wheel.name}"
+
+    def test_repair_is_idempotent(self, syslib_env: dict[str, Path], repaired_wheel: Path, tmp_path: Path):
+        """repair(repair(wheel)) must produce a byte-identical wheel."""
+        out2 = tmp_path / "repaired2"
+        out2.mkdir()
+        repaired2 = _run_repairwheel(repaired_wheel, syslib_env["lib_dir"], out2)
+
+        assert repaired_wheel.read_bytes() == repaired2.read_bytes(), (
+            "Repairing an already-repaired wheel produced different output"
+        )
+
+    def test_libpython_is_stripped(self, repaired_wheel: Path):
+        """The repaired extension must NOT have a DT_NEEDED on libpython.
+
+        Manylinux/musllinux wheels must not depend on libpython.
+        The vendored repair code calls ``remove_needed`` to strip it.
+        """
+        with zipfile.ZipFile(repaired_wheel) as zf:
+            ext_names = [n for n in zf.namelist() if n.endswith(sysconfig.get_config_var("EXT_SUFFIX"))]
+            assert ext_names, "No extension found in wheel"
+
+            import tempfile
+
+            with tempfile.TemporaryDirectory() as td:
+                td = Path(td)
+                for ext_name in ext_names:
+                    zf.extract(ext_name, td)
+                    ext_path = td / ext_name
+                    result = subprocess.run(
+                        ["readelf", "-d", str(ext_path)],
+                        capture_output=True,
+                        text=True,
+                    )
+                    needed = [line for line in result.stdout.splitlines() if "(NEEDED)" in line]
+                    for line in needed:
+                        assert "libpython" not in line, f"libpython should have been stripped: {line}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end SBOM test (requires libbz2-dev + dpkg)
+# ---------------------------------------------------------------------------
+
+# libbz2 is NOT on the manylinux allowlist, so it will be grafted.
+# dpkg can trace it back to a real package, so whichprovides succeeds
+# and an SBOM is generated.
+_BZ2_EXT_SOURCE = textwrap.dedent("""\
+    #define PY_SSIZE_T_CLEAN
+    #include <Python.h>
+    #include <bzlib.h>
+
+    static PyObject *
+    bz2_test_version(PyObject *self, PyObject *args)
+    {
+        return PyUnicode_FromString(BZ2_bzlibVersion());
+    }
+
+    static PyMethodDef methods[] = {
+        {"bz2version", bz2_test_version, METH_NOARGS, NULL},
+        {NULL, NULL, 0, NULL}
+    };
+
+    static struct PyModuleDef moddef = {
+        PyModuleDef_HEAD_INIT, "bz2_test", NULL, -1, methods
+    };
+
+    PyMODINIT_FUNC PyInit_bz2_test(void)
+    {
+        return PyModule_Create(&moddef);
+    }
+""")
+
+_has_dpkg = shutil.which("dpkg") is not None
+_has_bz2_dev = Path("/usr/include/bzlib.h").exists()
+_has_libbz2 = any(
+    Path(d).glob("libbz2.so*")
+    for d in ("/usr/lib/x86_64-linux-gnu", "/usr/lib/aarch64-linux-gnu", "/usr/lib")
+    if Path(d).is_dir()
+)
+
+
+def _build_bz2_ext(src_dir: Path, build_dir: Path) -> Path:
+    """Build a C extension that links against libbz2."""
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    out_file = build_dir / f"bz2_test{ext_suffix}"
+
+    src_file = src_dir / "bz2_test.c"
+    src_file.write_text(_BZ2_EXT_SOURCE)
+
+    include = sysconfig.get_path("include")
+
+    subprocess.check_call(
+        [
+            _cc(),
+            "-shared",
+            "-fPIC",
+            f"-I{include}",
+            "-Wl,--no-as-needed",
+            "-lbz2",
+            "-o",
+            str(out_file),
+            str(src_file),
+        ]
+    )
+    return out_file
+
+
+def _make_bz2_wheel(ext_file: Path, out_dir: Path) -> Path:
+    """Package the bz2 extension into a minimal wheel."""
+    machine = platform.machine()
+    py_ver = f"cp{sys.version_info[0]}{sys.version_info[1]}"
+    plat_tag = f"linux_{machine}"
+    tag = f"{py_ver}-{py_ver}-{plat_tag}"
+
+    wheel_name = "bz2test"
+    wheel_version = "0.0.1"
+
+    metadata = f"Metadata-Version: 2.1\nName: {wheel_name}\nVersion: {wheel_version}\n"
+    wheel_info = f"Wheel-Version: 1.0\nGenerator: test_syslib_integration\nRoot-Is-Purelib: false\nTag: {tag}\n"
+
+    ext_name = ext_file.name
+    dist_info = f"{wheel_name}-{wheel_version}.dist-info"
+    files: dict[str, bytes] = {
+        f"{wheel_name}/{ext_name}": ext_file.read_bytes(),
+        f"{dist_info}/METADATA": metadata.encode(),
+        f"{dist_info}/WHEEL": wheel_info.encode(),
+        f"{dist_info}/top_level.txt": b"bz2_test\n",
+    }
+
+    record_path = f"{dist_info}/RECORD"
+    records = []
+    for fname, data in sorted(files.items()):
+        digest = urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        records.append(f"{fname},sha256={digest},{len(data)}")
+    records.append(f"{record_path},,")
+    files[record_path] = "\n".join(records).encode()
+
+    wheel_path = out_dir / f"{wheel_name}-{wheel_version}-{tag}.whl"
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fname in sorted(files):
+            zinfo = zipfile.ZipInfo(fname, date_time=(1980, 1, 1, 0, 0, 0))
+            zinfo.external_attr = 0o100664 << 16
+            zf.writestr(zinfo, files[fname])
+
+    return wheel_path
+
+
+@pytest.mark.skipif(not _has_dpkg, reason="SBOM test requires dpkg")
+@pytest.mark.skipif(not _has_bz2_dev, reason="bzlib.h not found (need libbz2-dev)")
+@pytest.mark.skipif(not _has_libbz2, reason="libbz2.so not found (need libbz2-1.0)")
+class TestSbomEndToEnd:
+    """End-to-end SBOM test using libbz2 (a real, non-allowlisted system lib).
+
+    Because libbz2 is installed via the system package manager and is NOT
+    on the manylinux allowlist, repairwheel will:
+      1. Graft it into ``.libs/``
+      2. Have ``whichprovides`` identify its owning package
+      3. Generate an SBOM in ``.dist-info/sboms/``
+
+    This verifies the full SBOM pipeline including the monkeypatch that
+    prevents ``metadata.version('auditwheel')`` from crashing and
+    rebrands the output as ``repairwheel``.
+    """
+
+    @pytest.fixture()
+    def repaired_bz2_wheel(self, tmp_path: Path) -> Path:
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        out_dir = tmp_path / "repaired"
+        out_dir.mkdir()
+
+        ext = _build_bz2_ext(src_dir, build_dir)
+        wheel = _make_bz2_wheel(ext, wheel_dir)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "repairwheel",
+                str(wheel),
+                "--output-dir",
+                str(out_dir),
+            ],
+            env={**os.environ},
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"repairwheel exited {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+            )
+
+        results = list(out_dir.glob("*.whl"))
+        assert len(results) == 1
+        return results[0]
+
+    def test_repair_succeeds(self, repaired_bz2_wheel: Path):
+        assert repaired_bz2_wheel.exists()
+
+    def test_libbz2_is_bundled(self, repaired_bz2_wheel: Path):
+        with zipfile.ZipFile(repaired_bz2_wheel) as zf:
+            libs = [n for n in zf.namelist() if ".libs/" in n]
+        bz2_libs = [n for n in libs if "libbz2" in n]
+        assert bz2_libs, f"Expected libbz2 in .libs/, got: {libs}"
+
+    def test_sbom_file_is_named_repairwheel(self, repaired_bz2_wheel: Path):
+        """The SBOM file must be named repairwheel.cdx.json, not auditwheel."""
+        with zipfile.ZipFile(repaired_bz2_wheel) as zf:
+            names = zf.namelist()
+
+        sbom_entries = [n for n in names if n.endswith(".cdx.json")]
+        assert sbom_entries, f"No SBOM found in wheel; files: {names}"
+        assert all("repairwheel.cdx.json" in n for n in sbom_entries), (
+            f"SBOM filename should be repairwheel.cdx.json, got: {sbom_entries}"
+        )
+        assert not any("auditwheel.cdx.json" in n for n in names), "auditwheel.cdx.json should not exist in the wheel"
+
+    def test_sbom_content_is_branded_repairwheel(self, repaired_bz2_wheel: Path):
+        """The SBOM content must reference repairwheel, not auditwheel."""
+        import json
+
+        import repairwheel
+
+        with zipfile.ZipFile(repaired_bz2_wheel) as zf:
+            sbom_entry = next(n for n in zf.namelist() if n.endswith(".cdx.json"))
+            sbom_data = json.loads(zf.read(sbom_entry))
+
+        assert sbom_data["bomFormat"] == "CycloneDX"
+
+        tools = sbom_data["metadata"]["tools"]
+        assert len(tools) == 1
+        assert tools[0]["name"] == "repairwheel"
+        assert tools[0]["version"] == repairwheel.__version__
+
+        # Verify components include libbz2
+        component_names = [c["name"] for c in sbom_data.get("components", [])]
+        assert any("bz2" in n.lower() for n in component_names), f"Expected libbz2 in SBOM components, got: {component_names}"

--- a/tools/vendoring/patches/auditwheel.patch
+++ b/tools/vendoring/patches/auditwheel.patch
@@ -1,0 +1,34 @@
+diff --git a/src/repairwheel/_vendor/auditwheel/repair.py b/src/repairwheel/_vendor/auditwheel/repair.py
+index afea3e8..b5c21e8 100644
+--- a/src/repairwheel/_vendor/auditwheel/repair.py
++++ b/src/repairwheel/_vendor/auditwheel/repair.py
+@@ -139,7 +139,7 @@ def repair_wheel(
+         if sbom_data:
+             sbom_dir = Path(dist_info_dirs[0], "sboms")
+             sbom_dir.mkdir(exist_ok=True)
+-            (sbom_dir / "auditwheel.cdx.json").write_text(json.dumps(sbom_data))
++            (sbom_dir / "repairwheel.cdx.json").write_text(json.dumps(sbom_data))
+ 
+     return output_wheel
+ 
+diff --git a/src/repairwheel/_vendor/auditwheel/sboms.py b/src/repairwheel/_vendor/auditwheel/sboms.py
+index 59346ad..6e257d5 100644
+--- a/src/repairwheel/_vendor/auditwheel/sboms.py
++++ b/src/repairwheel/_vendor/auditwheel/sboms.py
+@@ -2,7 +2,6 @@ from __future__ import annotations
+ 
+ import hashlib
+ import typing
+-from importlib import metadata
+ from typing import TYPE_CHECKING
+ from urllib.parse import quote
+ 
+@@ -59,7 +58,7 @@ def create_sbom_for_wheel(
+         "metadata": {
+             "component": sbom_components[0],
+             "tools": [
+-                {"name": "auditwheel", "version": metadata.version("auditwheel")},
++                {"name": "repairwheel", "version": __import__("repairwheel").__version__},
+             ],
+         },
+         # These are mutated below through the variables.


### PR DESCRIPTION
-  Fixes system library path searching
- Fixes auditwheel's newer SBOM integration.
- Adds support for auditwheel's `remove_needed`.
- Adds an end-to-end test for system libraries, SBOM, and remove_needed cases.