### PR TITLE
feat: normalize file modes

### DIFF
--- a/src/repairwheel/__init__.py
+++ b/src/repairwheel/__init__.py
@@ -4,4 +4,4 @@
 repairwheel
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/src/repairwheel/wheel.py
+++ b/src/repairwheel/wheel.py
@@ -3,6 +3,7 @@ import csv
 import hashlib
 import operator
 import os
+import stat
 import zipfile
 from datetime import datetime
 from io import StringIO
@@ -116,8 +117,6 @@ def write_canonical_wheel(
     original_wheel: Path,
     patched_wheel: Path,
     out_dir: Path,
-    default_file_mode: int = 0o664,
-    default_dir_mode: int = 0o775,
     mtime: datetime | None = None,
     compression: int = zipfile.ZIP_DEFLATED,
 ) -> Path:
@@ -141,37 +140,49 @@ def write_canonical_wheel(
 
     mtime_args = mtime.timetuple()[:6]
 
-    def new_info(filename: str, is_dir: bool = False) -> ZipInfo:
+    def new_info(patched_info: ZipInfo) -> ZipInfo:
+        filename = patched_info.filename
         result = ZipInfo(filename, mtime_args)
         result.create_system = 3  # Always set the create system to be 'unixy'
-        result.file_size = 0  # Caller should set this for files
+
+        orig_mode = original_modes.get(filename, (patched_info.external_attr >> 16) & 0xFFFF)
+
+        is_dir = patched_info.is_dir()
+        is_symlink = stat.S_ISLNK(orig_mode)
+        is_exec = bool(orig_mode & 0o111)
+
         if is_dir:
-            mode = original_modes.get(filename, default_dir_mode)
-            result.external_attr = (mode & 0xFFFF) << 16
+            result.file_size = 0
+            result.external_attr = (stat.S_IFDIR | 0o755) << 16
             result.external_attr |= 0x10  # MS-DOS directory flag
+        elif is_symlink:
+            result.file_size = patched_info.file_size
+            result.external_attr = (stat.S_IFLNK | 0o777) << 16
         else:
+            result.file_size = patched_info.file_size
             result.compress_type = compression
-            mode = original_modes.get(filename, default_file_mode)
-            result.external_attr = (mode & 0xFFFF) << 16
+            perms = 0o755 if is_exec else 0o644
+            result.external_attr = (stat.S_IFREG | perms) << 16
 
         return result
 
     with ZipFile(patched_wheel) as patched_wheel_zip, ZipFile(out_wheel, mode="w", compression=compression) as out_wheel_zip:
         records = []
         for patched_info in _sorted_zip_entries(patched_wheel_zip):
+            out_info = new_info(patched_info)
             if patched_info.is_dir():
-                out_info = new_info(patched_info.filename, True)
                 out_wheel_zip.writestr(out_info, b"")
             else:
-                out_info = new_info(patched_info.filename)
-                out_info.file_size = patched_info.file_size
                 with patched_wheel_zip.open(patched_info) as in_file, out_wheel_zip.open(out_info, "w") as out_file:
                     hash, size = _copy_and_hash(in_file, out_file)
                     records.append((patched_info.filename, hash, size))
 
         # Write a new RECORD file at the end.
         record_name = f"{dist_info_dir}/RECORD"
-        record_info = new_info(record_name)
+        record_info = ZipInfo(record_name, mtime_args)
+        record_info.create_system = 3
+        record_info.compress_type = compression
+        record_info.external_attr = (stat.S_IFREG | 0o644) << 16
 
         record_buf = StringIO(newline="\n")
         record_writer = csv.writer(record_buf, delimiter=",", quotechar='"', lineterminator="\n")

--- a/src/repairwheel/wheel.py
+++ b/src/repairwheel/wheel.py
@@ -125,9 +125,7 @@ def write_canonical_wheel(
     * File and directory entries are lexicographically ordered
     * File data is written in the same order as corresponding names
     * All timestamps are set to a constant value
-
-    Because Windows doesn't support posix file modes, we use corresponding modes in the original file if they exist.
-    Else we use the default mode.
+    * File modes are normalized to 0o755 for directories and executables, 0o644 for regular files, and 0o777 for symlinks
     """
     if mtime is None:
         mtime = DEFAULT_MTIME
@@ -145,22 +143,19 @@ def write_canonical_wheel(
         result = ZipInfo(filename, mtime_args)
         result.create_system = 3  # Always set the create system to be 'unixy'
 
-        orig_mode = original_modes.get(filename, (patched_info.external_attr >> 16) & 0xFFFF)
+        orig_mode = original_modes.get(filename)
 
-        is_dir = patched_info.is_dir()
-        is_symlink = stat.S_ISLNK(orig_mode)
-        is_exec = bool(orig_mode & 0o111)
-
-        if is_dir:
+        if patched_info.is_dir():
             result.file_size = 0
             result.external_attr = (stat.S_IFDIR | 0o755) << 16
             result.external_attr |= 0x10  # MS-DOS directory flag
-        elif is_symlink:
+        elif orig_mode is not None and stat.S_ISLNK(orig_mode):
             result.file_size = patched_info.file_size
             result.external_attr = (stat.S_IFLNK | 0o777) << 16
         else:
             result.file_size = patched_info.file_size
             result.compress_type = compression
+            is_exec = bool(orig_mode & 0o111) if orig_mode is not None else False
             perms = 0o755 if is_exec else 0o644
             result.external_attr = (stat.S_IFREG | perms) << 16
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -141,3 +141,65 @@ def test_mixed_case_dist_info_preserved() -> None:
         record_files = [name for name in namelist if name.endswith("/RECORD")]
         assert len(record_files) == 1
         assert record_files[0] == "TestPackage-1.0.0.dist-info/RECORD"
+
+
+def test_canonical_wheel_permissions() -> None:
+    from repairwheel.wheel import write_canonical_wheel
+    import tempfile
+    import zipfile
+    import shutil
+    from pathlib import Path
+    import stat
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        wheel_name = "test_perms-1.0.0-py3-none-any.whl"
+
+        # Create a dummy original wheel
+        orig_wheel_path = tmpdir_path / wheel_name
+        with zipfile.ZipFile(orig_wheel_path, "w") as z:
+            # Create a directory with weird perms
+            dir_info = zipfile.ZipInfo("my_dir/")
+            dir_info.external_attr = (stat.S_IFDIR | 0o777) << 16
+            z.writestr(dir_info, b"")
+
+            # Create a regular file with weird perms
+            file_info = zipfile.ZipInfo("my_dir/file.txt")
+            file_info.external_attr = (stat.S_IFREG | 0o666) << 16
+            z.writestr(file_info, b"content")
+
+            # Create an executable file with weird perms
+            exec_info = zipfile.ZipInfo("my_dir/script.sh")
+            exec_info.external_attr = (stat.S_IFREG | 0o777) << 16
+            z.writestr(exec_info, b"echo hello")
+
+            # Create a symlink with weird perms
+            symlink_info = zipfile.ZipInfo("my_dir/symlink.txt")
+            symlink_info.external_attr = (stat.S_IFLNK | 0o755) << 16
+            z.writestr(symlink_info, b"file.txt")
+
+            metadata_content = b"Metadata-Version: 2.1\nName: test-perms\nVersion: 1.0.0\n"
+            z.writestr("test_perms-1.0.0.dist-info/METADATA", metadata_content)
+
+        patched_wheel_dir = tmpdir_path / "patched"
+        patched_wheel_dir.mkdir()
+        patched_wheel_path = patched_wheel_dir / wheel_name
+        shutil.copyfile(orig_wheel_path, patched_wheel_path)
+
+        out_dir = tmpdir_path / "out"
+        out_dir.mkdir()
+
+        out_wheel = write_canonical_wheel(orig_wheel_path, patched_wheel_path, out_dir)
+
+        # Verify output wheel permissions
+        with zipfile.ZipFile(out_wheel, "r") as z:
+            infos = {i.filename: i for i in z.infolist()}
+
+        assert infos["my_dir/"].external_attr == ((stat.S_IFDIR | 0o755) << 16) | 0x10
+        assert infos["my_dir/file.txt"].external_attr == (stat.S_IFREG | 0o644) << 16
+        assert infos["my_dir/script.sh"].external_attr == (stat.S_IFREG | 0o755) << 16
+        assert infos["my_dir/symlink.txt"].external_attr == (stat.S_IFLNK | 0o777) << 16
+
+        # Verify RECORD file was created and has 0o644
+        assert "test_perms-1.0.0.dist-info/RECORD" in infos
+        assert infos["test_perms-1.0.0.dist-info/RECORD"].external_attr == (stat.S_IFREG | 0o644) << 16

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,14 +1,17 @@
 import os
 import platform
+import stat
 import subprocess
 import sys
 import tempfile
+import shutil
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from repairwheel.wheel import write_canonical_wheel
 from .util import check_wheel_installs_and_runs, get_patched_wheel, is_wheel_compatible, TestWheel
 
 TEST_SOURCE_DATE_EPOCH = 1234567890
@@ -97,12 +100,6 @@ def test_repair_is_idempotent(patched_wheel: Path) -> None:
 
 
 def test_mixed_case_dist_info_preserved() -> None:
-    from repairwheel.wheel import write_canonical_wheel
-    import tempfile
-    import zipfile
-    import shutil
-    from pathlib import Path
-
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         wheel_name = "TestPackage-1.0.0-py3-none-any.whl"
@@ -144,13 +141,6 @@ def test_mixed_case_dist_info_preserved() -> None:
 
 
 def test_canonical_wheel_permissions() -> None:
-    from repairwheel.wheel import write_canonical_wheel
-    import tempfile
-    import zipfile
-    import shutil
-    from pathlib import Path
-    import stat
-
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         wheel_name = "test_perms-1.0.0-py3-none-any.whl"


### PR DESCRIPTION
Previously repairwheel attempted to maintain original modes, but this
sometimes led to differences based on the generating platform. Now we
bucket files into 4 groups (regular, executable, directory, symlink) and
assign a canonical mode per group.
